### PR TITLE
Add support for US AirNow

### DIFF
--- a/app/constants/urls.js
+++ b/app/constants/urls.js
@@ -5,5 +5,6 @@ module.exports = {
   MALAYSIA_URL: "http://apims.doe.gov.my/data/public/CAQM/last24hours.json",
   HONGKONG_URL:"http://www.aqhi.gov.hk/epd/ddata/html/out/24pc_Eng.xml",
   THAILAND_URL: "http://www.aqmthai.com/index.php?lang=en",
-  TAIWAN_URL: "http://opendata2.epa.gov.tw/AQI.json"
+  TAIWAN_URL: "http://opendata2.epa.gov.tw/AQI.json",
+  USA_URL: `https://www.airnowapi.org/aq/data/?parameters=PM25&BBOX=-124.205070,28.716781,-75.337882,45.419415&dataType=A&format=application%2Fjson&verbose=0&API_KEY=${process.env.AIRNOW_KEY}`
 }

--- a/app/helpers/geocoder.js
+++ b/app/helpers/geocoder.js
@@ -20,6 +20,29 @@ module.exports = {
       });
   },
 
+  getAddress: function(lat, lng) {
+    var params = {
+      latlng: `${lat},${lng}`,
+      key: GOOGLE_GEOCODING_API_KEY
+    };
+
+    return fetch('https://maps.googleapis.com/maps/api/geocode/json?' + this.makeParamsQueryString(params))
+    .then(function(res) {
+      return res.json();
+    })
+    .then(function(data) {
+      return data.results[0].address_components
+        .filter(component => component.types.includes('route') ||
+          component.types.includes('sublocality') ||
+          component.types.includes('locality'))
+        .map(component => component.short_name)
+        .join(', ');
+    })
+    .catch(function(error) {
+      console.log('geocoder request failed', error)
+    });
+  },
+
   makeParamsQueryString: function(params) {
     var esc = encodeURIComponent;
     return Object.keys(params)

--- a/app/scrapers/taiwan.js
+++ b/app/scrapers/taiwan.js
@@ -1,4 +1,5 @@
 const fetch = require('node-fetch');
+const Promise = require('bluebird');
 const urls = require('../constants/urls');
 const geocoder = require('../helpers/geocoder');
 
@@ -21,16 +22,14 @@ module.exports = {
         });
       })
       .then((citiesData) => {
-        let promises = citiesData.map(function(city) {
+        return Promise.map(citiesData, (city) => {
           var cityNameLookup = geocoderExceptions[city.name] || city.name
           return geocoder.getLatLng(cityNameLookup)
             .then(function(locationObj) {
               city.location = locationObj;
               return city;
-            })
-        });
-
-        return Promise.all(promises)
+            });
+        }, { concurrency: 5 })
           .then(function(results) {
             return results;
           })

--- a/app/scrapers/usa.js
+++ b/app/scrapers/usa.js
@@ -1,0 +1,40 @@
+const fetch = require('node-fetch');
+const Promise = require('bluebird');
+const urls = require('../constants/urls');
+const geocoder = require('../helpers/geocoder');
+
+module.exports = {
+  scrape: () => {
+    return fetch(urls.USA_URL)
+      .then((response) => {
+        return response.json();
+      })
+      .then((json) => {
+        return json.map((city) => {
+          return  {
+            name: null,
+            data: parseInt( city['AQI'], 10) || 0,
+            location: {
+              lat: city.Latitude,
+              lng: city.Longitude
+            }
+          }
+        });
+      })
+      .then((citiesData) => {
+        return Promise.map(citiesData, (city) => {
+          return geocoder.getAddress(city.location.lat, city.location.lng)
+            .then(function(address) {
+              city.name = address;
+              return city;
+            });
+        }, { concurrency: 5 })
+          .then(function(results) {
+            return results;
+          })
+          .catch(function(error) {
+            console.log(error);
+          });
+      });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "bluebird": "^3.5.1",
     "cheerio": "^0.22.0",
     "dotenv": "^2.0.0",
     "moment": "^2.14.1",


### PR DESCRIPTION
# Purpose
This PR adds support for the US AirNow service.

# Implementation
- Add reverse-geocoding function to `geocoder.js`
- Use bluebird Promises for Taiwan & US scrapers
  - Throttle requests in these scrapers to a maximum of 5 at once, to avoid rate limits and potential crashes in Node.js